### PR TITLE
bug fixed: 크기 조절 시 이미지가 보여지는 버그

### DIFF
--- a/mapapp/static/mapapp/script.js
+++ b/mapapp/static/mapapp/script.js
@@ -577,6 +577,13 @@ function loadMapAndStations() {
   const listContainer = document.getElementById("list-container");
   showLoadingMessage(listContainer, "현재 위치를 찾는 중...");
 
+    // 기존 지도가 있다면 완전히 제거
+  if (map) {
+    map = null;
+    const mapContainer = document.getElementById("map");
+    mapContainer.innerHTML = '';
+  }
+
   navigator.geolocation.getCurrentPosition(
     (position) => {
       currentLat = position.coords.latitude;


### PR DESCRIPTION
## Related Issue
- 버그 내용

    처음 충전소 위치를 탐색 후, 위치 재탐색 버튼을 클릭하여 충전소 정보를 로딩 하고 있는 중에 지도 크기를 조절하면 버튼 탐색 이전의 이미지가 중간에 보여지는 버그 발생

- 버그 발생 과정
  1. 초기 프로그램 실행 시 자동으로 위치 탐색
  2. 지도 상에 충전소 마커 표시
  3. 위치 재탐색 버튼 클릭
  4. 충전소 정보 로딩 중 지도 크기 조절

## Category
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Description
- 해결 방법

   위치 재탐색 기능을 수행할 때 기존의 탐색한 지도가 있으면 해당 지도를 제거하여 크기 조절 시 보이지 않도록 수정하였습니다.
<!-- You can erase any parts of this template not applicable to your Pull Request. -->